### PR TITLE
[MAT-7190] Set HQMF ID and Display Data Element ID's as simple strings

### DIFF
--- a/model/mongoid.rb
+++ b/model/mongoid.rb
@@ -1,0 +1,11 @@
+# Override the as_json method to ensure the _id is displayed as
+# just the _id value as a string in the QRDA XML, "<_id>".
+# Without this override it will be serialized as extended
+# BSON::JSON, "{$oid => "<_id>"}"
+module BSON
+  class ObjectId
+    def as_json(*args)
+      to_s.as_json
+    end
+  end
+end

--- a/service/app.rb
+++ b/service/app.rb
@@ -64,6 +64,7 @@ put "/api/qrda" do
 
   measure.source_data_criteria = data_criteria
   measure.cms_id = measure.cms_id.nil? ? 'CMS0v0' : measure.cms_id
+  measure.hqmf_id = madie_measure["id"]
 
   qrda_errors = {}
   html_errors = {}

--- a/service/app.rb
+++ b/service/app.rb
@@ -48,7 +48,12 @@ put "/api/qrda" do
   access_token = request.env["HTTP_Authorization"]
   measure_dto = request.params
 
-  measure = CQM::Measure.new(JSON.parse(measure_dto["measure"]))
+  madie_measure = JSON.parse(measure_dto["measure"])
+  measure = CQM::Measure.new(madie_measure) unless madie_measure.nil?
+  if measure.nil?
+    return [400, "Measure is empty."]
+  end
+
   test_cases = measure_dto["testCases"]
   source_data_criteria = measure_dto["sourceDataCriteria"]
 


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7190](https://jira.cms.gov/browse/MAT-7190)
(Optional) Related Tickets:

### Summary

Various fixes for issues identified by SMEs:

- MAT-7190: Gracefully handle empty, non-compliant measure input.
- MAT-7190: Set the CQM::Measure HQMF ID as the madie measure ID.
- MAT-7190: Display the Data Element's ID as a simple string value, instead of as `"{$oid => "<_id>"}"` in the QRDA XML.

### All Submissions
* [x] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
