### PR TITLE
MAT-7584: Lock mongoid to 8.x. 9.x versions caused runtime errors, unable to find Time.zone.parse().

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'cqm-reports', '4.1.2'
 gem 'rackup', '~> 2.1'
 gem 'rack-contrib', '~> 2.5', '>= 2.5.0'
 gem 'jwt'
+gem 'mongoid', '~> 8.1.5'
 
 gem 'cqm-models', :git => 'https://github.com/projecttacoma/cqm-models', :branch => 'master'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.1.3.4)
-      activesupport (= 7.1.3.4)
-    activesupport (7.1.3.4)
+    activemodel (7.1.4)
+      activesupport (= 7.1.4)
+    activesupport (7.1.4)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -59,10 +59,11 @@ GEM
     minitest (5.22.2)
     mongo (2.20.1)
       bson (>= 4.14.1, < 6.0.0)
-    mongoid (9.0.1)
+    mongoid (8.1.5)
       activemodel (>= 5.1, < 7.2, != 7.0.0)
       concurrent-ruby (>= 1.0.5, < 2.0)
       mongo (>= 2.18.0, < 3.0.0)
+      ruby2_keywords (~> 0.0.5)
     mongoid-tree (2.3.0)
       mongoid (>= 4.0, < 10)
     mustache (1.1.1)
@@ -128,6 +129,7 @@ DEPENDENCIES
   cqm-reports (= 4.1.2)
   jwt
   minitest
+  mongoid (~> 8.1.5)
   passenger
   rack-contrib (~> 2.5, >= 2.5.0)
   rack-test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7584](https://jira.cms.gov/browse/MAT-7584)
(Optional) Related Tickets:

### Summary

Mongoid 9.x caused a NoMethodError when trying `Time.zone.parse()`. Bandage fix by rolling back to last known good version (8.1.5).

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
