### PR TITLE
MAT-9336: Remove counter prefix from summary page's link targets

### DIFF
--- a/views/top_level_summary.erb
+++ b/views/top_level_summary.erb
@@ -136,12 +136,12 @@
             <% result = (!pop_fail(test_case) && !strat_fail(test_case)) ? 'pass' : 'fail' %>
             <span class="<%= result %>"><%= result %>: </span>
             <% unless html_errors[test_case["testCaseId"]] %>
-              <a href="<%= File.join(".","html","#{index+1}_#{test_case["lastName"]}_#{test_case["firstName"]}.html")%>"><%=test_case["lastName"]%>, <%=test_case["firstName"]%></a>
+              <a href="<%= File.join(".","html","#{test_case["lastName"]}_#{test_case["firstName"]}.html")%>"><%=test_case["lastName"]%>, <%=test_case["firstName"]%></a>
             <% else %>
               <%=test_case["lastName"]%>, <%=test_case["firstName"]%>
             <% end %>
             <% unless qrda_errors[test_case["testCaseId"]] %>
-              <a class="btn" href="<%= File.join(".","qrda","#{index+1}_#{test_case["lastName"]}_#{test_case["firstName"]}.xml")%>">qrda</a>
+              <a class="btn" href="<%= File.join(".","qrda","#{test_case["lastName"]}_#{test_case["firstName"]}.xml")%>">qrda</a>
             <% end %>
           </h2>
         </td>


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9336](https://jira.cms.gov/browse/MAT-9336)
(Optional) Related Tickets:

### Summary

Forget to remove the counter prefix from the URLs in the summary page.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
